### PR TITLE
roleが元のメソッドを実行するように修正 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ phpunit.xml
 composer.lock
 vendor/
 .php_cs.cache
-tests/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ phpunit.xml
 composer.lock
 vendor/
 .php_cs.cache
+tests/tmp

--- a/src/AclEmbedInterceptor.php
+++ b/src/AclEmbedInterceptor.php
@@ -77,7 +77,7 @@ final class AclEmbedInterceptor implements MethodInterceptor
         $role = $this->roleProvider->get();
         $this->embedded($resources, $role, $ro);
 
-        return $ro;
+        return $this->$invocation->proceed();
     }
 
     private function getNamedParams(MethodInvocation $invocation) : array
@@ -112,7 +112,8 @@ final class AclEmbedInterceptor implements MethodInterceptor
             }
             try {
                 $pathIndex = substr($path, 1);
-                $ro->body[$pathIndex] = clone $this->resource->uri($uri);
+                $rel = str_replace('/', '_', $pathIndex);
+                $ro->body[$rel] = clone $this->resource->uri($uri);
             } catch (BadRequestException $e) {
                 throw new NotFoundResourceException($uri, 500, $e);
             }


### PR DESCRIPTION
# 概要
 - roleがアクセス可能の際に元のメソッドを実行するように修正
 - テンプレートに渡す際に'/'が除算をしてしまうため、'_'に置換するように修正